### PR TITLE
Queue trimming

### DIFF
--- a/RedisStreamsProvider.UnitTests/RedisStreamBatchContainerTests.cs
+++ b/RedisStreamsProvider.UnitTests/RedisStreamBatchContainerTests.cs
@@ -89,7 +89,7 @@ namespace RedisStreamsProvider.UnitTests
         private class TestEvent
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string? Name { get; set; }
         }
     }
 }

--- a/RedisStreamsProvider.UnitTests/RedisStreamFactoryTests.cs
+++ b/RedisStreamsProvider.UnitTests/RedisStreamFactoryTests.cs
@@ -5,6 +5,7 @@ using Orleans.Providers.Streams.Common;
 using Orleans.Streams;
 using StackExchange.Redis;
 using Universley.OrleansContrib.StreamsProvider.Redis;
+using Microsoft.Extensions.Options;
 
 namespace RedisStreamsProvider.UnitTests
 {
@@ -17,6 +18,7 @@ namespace RedisStreamsProvider.UnitTests
         private readonly SimpleQueueCacheOptions _simpleQueueCacheOptions;
         private readonly HashRingStreamQueueMapperOptions _hashRingStreamQueueMapperOptions;
         private readonly string _providerName = "TestProvider";
+        private readonly Mock<IOptions<RedisStreamReceiverOptions>> _mockReceiverOptions;
 
         public RedisStreamFactoryTests()
         {
@@ -28,23 +30,26 @@ namespace RedisStreamsProvider.UnitTests
             _mockStreamFailureHandler = new Mock<IStreamFailureHandler>();
             _simpleQueueCacheOptions = new SimpleQueueCacheOptions();
             _hashRingStreamQueueMapperOptions = new HashRingStreamQueueMapperOptions();
+            _mockReceiverOptions = new Mock<IOptions<RedisStreamReceiverOptions>>();
+            _mockReceiverOptions.Setup(o => o.Value).Returns(new RedisStreamReceiverOptions());
         }
 
         [Fact]
         public void Constructor_ShouldThrowArgumentNullException_WhenAnyArgumentIsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => new RedisStreamFactory(null, _mockLoggerFactory.Object, _providerName, _mockStreamFailureHandler.Object, _simpleQueueCacheOptions, _hashRingStreamQueueMapperOptions));
-            Assert.Throws<ArgumentNullException>(() => new RedisStreamFactory(_mockConnectionMultiplexer.Object, null, _providerName, _mockStreamFailureHandler.Object, _simpleQueueCacheOptions, _hashRingStreamQueueMapperOptions));
-            Assert.Throws<ArgumentNullException>(() => new RedisStreamFactory(_mockConnectionMultiplexer.Object, _mockLoggerFactory.Object, null, _mockStreamFailureHandler.Object, _simpleQueueCacheOptions, _hashRingStreamQueueMapperOptions));
-            Assert.Throws<ArgumentNullException>(() => new RedisStreamFactory(_mockConnectionMultiplexer.Object, _mockLoggerFactory.Object, _providerName, null, _simpleQueueCacheOptions, _hashRingStreamQueueMapperOptions));
-            Assert.Throws<ArgumentNullException>(() => new RedisStreamFactory(_mockConnectionMultiplexer.Object, _mockLoggerFactory.Object, _providerName, _mockStreamFailureHandler.Object, null, _hashRingStreamQueueMapperOptions));
-            Assert.Throws<ArgumentNullException>(() => new RedisStreamFactory(_mockConnectionMultiplexer.Object, _mockLoggerFactory.Object, _providerName, _mockStreamFailureHandler.Object, _simpleQueueCacheOptions, null));
+            Assert.Throws<ArgumentNullException>(() => new RedisStreamFactory(null!, _mockLoggerFactory.Object, _providerName, _mockStreamFailureHandler.Object, _simpleQueueCacheOptions, _hashRingStreamQueueMapperOptions, _mockReceiverOptions.Object));
+            Assert.Throws<ArgumentNullException>(() => new RedisStreamFactory(_mockConnectionMultiplexer.Object, null!, _providerName, _mockStreamFailureHandler.Object, _simpleQueueCacheOptions, _hashRingStreamQueueMapperOptions, _mockReceiverOptions.Object));
+            Assert.Throws<ArgumentNullException>(() => new RedisStreamFactory(_mockConnectionMultiplexer.Object, _mockLoggerFactory.Object, null!, _mockStreamFailureHandler.Object, _simpleQueueCacheOptions, _hashRingStreamQueueMapperOptions, _mockReceiverOptions.Object));
+            Assert.Throws<ArgumentNullException>(() => new RedisStreamFactory(_mockConnectionMultiplexer.Object, _mockLoggerFactory.Object, _providerName, null!, _simpleQueueCacheOptions, _hashRingStreamQueueMapperOptions, _mockReceiverOptions.Object));
+            Assert.Throws<ArgumentNullException>(() => new RedisStreamFactory(_mockConnectionMultiplexer.Object, _mockLoggerFactory.Object, _providerName, _mockStreamFailureHandler.Object, null!, _hashRingStreamQueueMapperOptions, _mockReceiverOptions.Object));
+            Assert.Throws<ArgumentNullException>(() => new RedisStreamFactory(_mockConnectionMultiplexer.Object, _mockLoggerFactory.Object, _providerName, _mockStreamFailureHandler.Object, _simpleQueueCacheOptions, null!, _mockReceiverOptions.Object));
+            Assert.Throws<ArgumentNullException>(() => new RedisStreamFactory(_mockConnectionMultiplexer.Object, _mockLoggerFactory.Object, _providerName, _mockStreamFailureHandler.Object, _simpleQueueCacheOptions, _hashRingStreamQueueMapperOptions, null!));
         }
 
         [Fact]
         public async Task CreateAdapter_ShouldReturnRedisStreamAdapterInstance()
         {
-            var factory = new RedisStreamFactory(_mockConnectionMultiplexer.Object, _mockLoggerFactory.Object, _providerName, _mockStreamFailureHandler.Object, _simpleQueueCacheOptions, _hashRingStreamQueueMapperOptions);
+            var factory = new RedisStreamFactory(_mockConnectionMultiplexer.Object, _mockLoggerFactory.Object, _providerName, _mockStreamFailureHandler.Object, _simpleQueueCacheOptions, _hashRingStreamQueueMapperOptions, _mockReceiverOptions.Object);
 
             var adapter = await factory.CreateAdapter();
 
@@ -55,7 +60,7 @@ namespace RedisStreamsProvider.UnitTests
         [Fact]
         public async Task GetDeliveryFailureHandler_ShouldReturnStreamFailureHandler()
         {
-            var factory = new RedisStreamFactory(_mockConnectionMultiplexer.Object, _mockLoggerFactory.Object, _providerName, _mockStreamFailureHandler.Object, _simpleQueueCacheOptions, _hashRingStreamQueueMapperOptions);
+            var factory = new RedisStreamFactory(_mockConnectionMultiplexer.Object, _mockLoggerFactory.Object, _providerName, _mockStreamFailureHandler.Object, _simpleQueueCacheOptions, _hashRingStreamQueueMapperOptions, _mockReceiverOptions.Object);
 
             var handler = await factory.GetDeliveryFailureHandler(new QueueId());
 
@@ -66,7 +71,7 @@ namespace RedisStreamsProvider.UnitTests
         [Fact]
         public void GetQueueAdapterCache_ShouldReturnSimpleQueueAdapterCacheInstance()
         {
-            var factory = new RedisStreamFactory(_mockConnectionMultiplexer.Object, _mockLoggerFactory.Object, _providerName, _mockStreamFailureHandler.Object, _simpleQueueCacheOptions, _hashRingStreamQueueMapperOptions);
+            var factory = new RedisStreamFactory(_mockConnectionMultiplexer.Object, _mockLoggerFactory.Object, _providerName, _mockStreamFailureHandler.Object, _simpleQueueCacheOptions, _hashRingStreamQueueMapperOptions, _mockReceiverOptions.Object);
 
             var cache = factory.GetQueueAdapterCache();
 
@@ -77,7 +82,7 @@ namespace RedisStreamsProvider.UnitTests
         [Fact]
         public void GetStreamQueueMapper_ShouldReturnHashRingBasedStreamQueueMapperInstance()
         {
-            var factory = new RedisStreamFactory(_mockConnectionMultiplexer.Object, _mockLoggerFactory.Object, _providerName, _mockStreamFailureHandler.Object, _simpleQueueCacheOptions, _hashRingStreamQueueMapperOptions);
+            var factory = new RedisStreamFactory(_mockConnectionMultiplexer.Object, _mockLoggerFactory.Object, _providerName, _mockStreamFailureHandler.Object, _simpleQueueCacheOptions, _hashRingStreamQueueMapperOptions, _mockReceiverOptions.Object);
 
             var mapper = factory.GetStreamQueueMapper();
 
@@ -88,8 +93,12 @@ namespace RedisStreamsProvider.UnitTests
         [Fact]
         public void Create_ShouldThrowException_WhenServiceProviderIsNull()
         {
+            // Arrange
+            // No need to mock GetService for IOptions<RedisStreamReceiverOptions> here, 
+            // as the ArgumentNullException for services should be thrown first.
+            
             // Act & Assert
-            Assert.Throws<ArgumentNullException>(() => RedisStreamFactory.Create(null, _providerName));
+            Assert.Throws<ArgumentNullException>(() => RedisStreamFactory.Create(null!, _providerName));
         }
     }
 }

--- a/RedisStreamsProvider.UnitTests/RedisStreamReceiverTests.cs
+++ b/RedisStreamsProvider.UnitTests/RedisStreamReceiverTests.cs
@@ -109,9 +109,9 @@ namespace RedisStreamsProvider.UnitTests
                 logger => logger.Log(
                     It.Is<LogLevel>(logLevel => logLevel == LogLevel.Error),
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Error initializing stream")),
+                    It.Is<It.IsAnyType>((v, t) => v != null && v.ToString()!.Contains("Error initializing stream")),
                     It.IsAny<Exception>(),
-                    It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)),
+                    It.Is<Func<It.IsAnyType, Exception?, string>>((v, t) => true)),
                 Times.Once);
         }
 
@@ -180,9 +180,9 @@ namespace RedisStreamsProvider.UnitTests
                 logger => logger.Log(
                     It.Is<LogLevel>(logLevel => logLevel == LogLevel.Error),
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Error acknowledging messages in stream")),
+                    It.Is<It.IsAnyType>((v, t) => v != null && v.ToString()!.Contains("Error acknowledging messages in stream")),
                     It.IsAny<Exception>(),
-                    It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)),
+                    It.Is<Func<It.IsAnyType, Exception?, string>>((v, t) => true)),
                 Times.Once);
         }
 

--- a/RedisStreamsProvider.UnitTests/RedisStreamReceiverTrimTests.cs
+++ b/RedisStreamsProvider.UnitTests/RedisStreamReceiverTrimTests.cs
@@ -1,0 +1,158 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Orleans.Streams;
+using StackExchange.Redis;
+using Universley.OrleansContrib.StreamsProvider.Redis;
+using System.Reflection;
+using Microsoft.Extensions.Time.Testing; // Added for FakeTimeProvider
+using System; // Added for DateTimeOffset
+
+namespace RedisStreamsProvider.UnitTests
+{
+    public class RedisStreamReceiverTrimTests
+    {
+        private readonly Mock<IDatabase> _mockDatabase;
+        private readonly Mock<ILogger<RedisStreamReceiver>> _mockLogger;
+        private readonly QueueId _queueId;
+        private RedisStreamReceiver _receiver;
+        private FakeTimeProvider _fakeTimeProvider; // Added FakeTimeProvider
+        private DateTimeOffset _initialTime;
+
+        public RedisStreamReceiverTrimTests()
+        {
+            _mockDatabase = new Mock<IDatabase>();
+            _mockLogger = new Mock<ILogger<RedisStreamReceiver>>();
+            _queueId = new QueueId();
+            _initialTime = new DateTimeOffset(2025, 5, 13, 12, 0, 0, TimeSpan.Zero);
+            _fakeTimeProvider = new FakeTimeProvider(_initialTime); // Initialize FakeTimeProvider
+            _receiver = new RedisStreamReceiver(_queueId, _mockDatabase.Object, _mockLogger.Object, _fakeTimeProvider);
+        }
+
+        [Fact]
+        public async Task TrimStreamIfNeeded_ShouldNotTrim_WhenTimeIntervalNotExceeded()
+        {
+            // Arrange
+            // _lastTrimTime is _initialTime due to constructor setup.
+            // Advance current time by less than TrimTimeMinutes.
+            _fakeTimeProvider.Advance(TimeSpan.FromMinutes(RedisStreamReceiver.TrimTimeMinutes - 1));
+
+            // Act
+            await _receiver.TrimStreamIfNeeded();
+
+            // Assert
+            _mockDatabase.Verify(
+                db => db.StreamTrimAsync(It.IsAny<RedisKey>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CommandFlags>()),
+                Moq.Times.Never());
+        }
+
+        [Fact]
+        public async Task TrimStreamIfNeeded_ShouldTrim_WhenTimeIntervalExceeded()
+        {
+            // Arrange
+            // _lastTrimTime is _initialTime.
+            // Advance current time by more than TrimTimeMinutes to trigger trim.
+            _fakeTimeProvider.Advance(TimeSpan.FromMinutes(RedisStreamReceiver.TrimTimeMinutes + 1));
+            _mockDatabase
+                .Setup(db => db.StreamTrimAsync(_queueId.ToString(), RedisStreamReceiver.MaxStreamLength, true, It.IsAny<CommandFlags>()))
+                .Returns(Task.FromResult<long>(10));
+
+            // Act
+            await _receiver.TrimStreamIfNeeded();
+
+            // Assert
+            _mockDatabase.Verify(
+                db => db.StreamTrimAsync(_queueId.ToString(), RedisStreamReceiver.MaxStreamLength, true, It.IsAny<CommandFlags>()),
+                Moq.Times.Once());
+        }
+
+        [Fact]
+        public async Task TrimStreamIfNeeded_ShouldUpdateLastTrimTime_WhenTrimSucceeds()
+        {
+            // Arrange
+            var timeToTriggerTrim = TimeSpan.FromMinutes(RedisStreamReceiver.TrimTimeMinutes + 1);
+            _fakeTimeProvider.Advance(timeToTriggerTrim);
+
+            _mockDatabase
+                .Setup(db => db.StreamTrimAsync(_queueId.ToString(), RedisStreamReceiver.MaxStreamLength, true, It.IsAny<CommandFlags>()))
+                .Returns(Task.FromResult<long>(10));
+
+            // Act
+            await _receiver.TrimStreamIfNeeded();
+
+            // Assert
+            // After trimming, _lastTrimTime should be updated to the time of the trim.
+            // To verify this, advance time slightly and try to trim again. It should not trim.
+            _mockDatabase.Invocations.Clear();
+            _fakeTimeProvider.Advance(TimeSpan.FromMinutes(1)); // Advance time slightly
+            await _receiver.TrimStreamIfNeeded();
+
+            _mockDatabase.Verify(
+                db => db.StreamTrimAsync(_queueId.ToString(), RedisStreamReceiver.MaxStreamLength, true, It.IsAny<CommandFlags>()),
+                Moq.Times.Never());
+        }
+
+        [Fact]
+        public async Task TrimStreamIfNeeded_ShouldLogError_WhenTrimFails()
+        {
+            // Arrange
+            var exception = new RedisException("Test exception");
+            _fakeTimeProvider.Advance(TimeSpan.FromMinutes(RedisStreamReceiver.TrimTimeMinutes + 1));
+            _mockDatabase
+                .Setup(db => db.StreamTrimAsync(_queueId.ToString(), RedisStreamReceiver.MaxStreamLength, true, It.IsAny<CommandFlags>()))
+                .Returns(Task.FromException<long>(exception));
+
+            // Act
+            await _receiver.TrimStreamIfNeeded();
+
+            // Assert
+            _mockLogger.Verify(
+                logger => logger.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Error trimming stream")),
+                    It.Is<Exception>(ex => ex == exception),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Moq.Times.Once());
+        }
+
+        [Fact]
+        public async Task GetQueueMessagesAsync_ShouldCallTrimStreamIfNeeded()
+        {
+            // Arrange
+            var fakeTimeProviderForTestReceiver = new FakeTimeProvider(_initialTime);
+            var testReceiver = new TestReceiver(_queueId, _mockDatabase.Object, _mockLogger.Object, fakeTimeProviderForTestReceiver);
+            fakeTimeProviderForTestReceiver.Advance(TimeSpan.FromMinutes(RedisStreamReceiver.TrimTimeMinutes + 1));
+
+            var streamEntries = Array.Empty<StreamEntry>();
+            _mockDatabase
+                .Setup(db => db.StreamReadGroupAsync(_queueId.ToString(), It.IsAny<RedisValue>(), It.IsAny<RedisValue>(), It.IsAny<RedisValue>(), It.IsAny<int>(), false, It.IsAny<CommandFlags>()))
+                .Returns(Task.FromResult(streamEntries));
+            _mockDatabase
+                .Setup(db => db.StreamTrimAsync(_queueId.ToString(), RedisStreamReceiver.MaxStreamLength, true, It.IsAny<CommandFlags>()))
+                .Returns(Task.FromResult<long>(0));
+
+            // Act
+            await testReceiver.GetQueueMessagesAsync(10);
+
+            // Assert
+            Assert.True(testReceiver.WasTrimCalled, "TrimStreamIfNeeded should have been called");
+        }
+
+        private class TestReceiver : RedisStreamReceiver
+        {
+            public bool WasTrimCalled { get; private set; }
+
+            public TestReceiver(QueueId queueId, IDatabase database, ILogger<RedisStreamReceiver> logger, TimeProvider timeProvider)
+                : base(queueId, database, logger, timeProvider) // Pass TimeProvider to base
+            {
+                WasTrimCalled = false;
+            }
+
+            public override async Task TrimStreamIfNeeded()
+            {
+                WasTrimCalled = true;
+                await base.TrimStreamIfNeeded();
+            }
+        }
+    }
+}

--- a/RedisStreamsProvider.UnitTests/RedisStreamSequenceTokenTests.cs
+++ b/RedisStreamsProvider.UnitTests/RedisStreamSequenceTokenTests.cs
@@ -113,7 +113,7 @@ namespace RedisStreamsProvider.UnitTests
             var token = new RedisStreamSequenceToken(123, 456);
 
             // Act & Assert
-            Assert.Throws<ArgumentNullException>(() => token.CompareTo(null));
+            Assert.Throws<ArgumentNullException>(() => token.CompareTo(null!));
         }
 
         [Fact]

--- a/RedisStreamsProvider.UnitTests/RedisStreamsProvider.UnitTests.csproj
+++ b/RedisStreamsProvider.UnitTests/RedisStreamsProvider.UnitTests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/Universley.OrleansContrib.StreamsProvider.Redis/RedisStreamReceiver.cs
+++ b/Universley.OrleansContrib.StreamsProvider.Redis/RedisStreamReceiver.cs
@@ -13,8 +13,8 @@ namespace Universley.OrleansContrib.StreamsProvider.Redis
         private string _lastId = "0";
         private Task? pendingTasks;
         private DateTimeOffset _lastTrimTime;
-        public const int MaxStreamLength = 1000;
-        public const int TrimTimeMinutes = 5;
+        public const int MaxStreamLength = 128;
+        public const int TrimTimeMinutes = 1;
 
         private TimeProvider _timeProvider;
 
@@ -66,6 +66,7 @@ namespace Universley.OrleansContrib.StreamsProvider.Redis
                 {
                     var trim = await _database.StreamTrimAsync(_queueId.ToString(), MaxStreamLength, useApproximateMaxLength: true);
                     _lastTrimTime = _timeProvider.GetUtcNow();
+                    _logger.LogDebug("Trimmed stream {QueueId} to {MaxStreamLength} entries at {Time}", _queueId, MaxStreamLength, _lastTrimTime);
                 }
                 catch (Exception ex)
                 {

--- a/Universley.OrleansContrib.StreamsProvider.Redis/RedisStreamReceiverOptions.cs
+++ b/Universley.OrleansContrib.StreamsProvider.Redis/RedisStreamReceiverOptions.cs
@@ -1,0 +1,8 @@
+namespace Universley.OrleansContrib.StreamsProvider.Redis
+{
+    public class RedisStreamReceiverOptions
+    {
+        public int MaxStreamLength { get; set; } = 1000; // Default value from previous const
+        public int TrimTimeMinutes { get; set; } = 5;   // Default value from previous const
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature to the `RedisStreamReceiver` class for stream trimming based on time intervals and enhances its test coverage. The changes include adding a `TimeProvider` to manage time-based operations, implementing the `TrimStreamIfNeeded` method, and creating comprehensive unit tests to validate the functionality.

### Enhancements to `RedisStreamReceiver`:

* Introduced a `TimeProvider` to handle time-based operations, allowing for better testability and flexibility. The `RedisStreamReceiver` constructor now accepts an optional `TimeProvider`, defaulting to `TimeProvider.System` if none is provided. (`Universley.OrleansContrib.StreamsProvider.Redis/RedisStreamReceiver.cs`, [Universley.OrleansContrib.StreamsProvider.Redis/RedisStreamReceiver.csR15-R33](diffhunk://#diff-89f1a08ffcc22a54e743cb572d343772614a0ff2c32c89ba20c7535985f50e2aR15-R33))
* Added the `TrimStreamIfNeeded` method to trim the Redis stream when the specified time interval (`TrimTimeMinutes`) is exceeded. This method logs errors if trimming fails. (`Universley.OrleansContrib.StreamsProvider.Redis/RedisStreamReceiver.cs`, [Universley.OrleansContrib.StreamsProvider.Redis/RedisStreamReceiver.csR61-R76](diffhunk://#diff-89f1a08ffcc22a54e743cb572d343772614a0ff2c32c89ba20c7535985f50e2aR61-R76))
* Integrated the `TrimStreamIfNeeded` method into the `GetQueueMessagesAsync` method to ensure stream trimming is checked during message retrieval. (`Universley.OrleansContrib.StreamsProvider.Redis/RedisStreamReceiver.cs`, [Universley.OrleansContrib.StreamsProvider.Redis/RedisStreamReceiver.csR44-R45](diffhunk://#diff-89f1a08ffcc22a54e743cb572d343772614a0ff2c32c89ba20c7535985f50e2aR44-R45))

### Unit Test Additions:

* Created the `RedisStreamReceiverTrimTests` class to validate the new stream trimming functionality. Tests include scenarios for no trimming, successful trimming, logging errors on failures, and ensuring trimming updates the last trim time. (`RedisStreamsProvider.UnitTests/RedisStreamReceiverTrimTests.cs`, [RedisStreamsProvider.UnitTests/RedisStreamReceiverTrimTests.csR1-R158](diffhunk://#diff-29f18d2a0b670eaa2f33c26833045ba9add168b4f34331693ceca800a745809cR1-R158))
* Added a `TestReceiver` class to facilitate testing by overriding the `TrimStreamIfNeeded` method. (`RedisStreamsProvider.UnitTests/RedisStreamReceiverTrimTests.cs`, [RedisStreamsProvider.UnitTests/RedisStreamReceiverTrimTests.csR1-R158](diffhunk://#diff-29f18d2a0b670eaa2f33c26833045ba9add168b4f34331693ceca800a745809cR1-R158))

### Dependency Updates:

* Added the `Microsoft.Extensions.TimeProvider.Testing` package to support the use of `FakeTimeProvider` in unit tests. (`RedisStreamsProvider.UnitTests/RedisStreamsProvider.UnitTests.csproj`, [RedisStreamsProvider.UnitTests/RedisStreamsProvider.UnitTests.csprojR12](diffhunk://#diff-710403d48f0224bd6a2a759ca253256f2d8374efddaffa3a9858e85700e98398R12))